### PR TITLE
fix: resolve issues preventing CI to succeed

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -65,3 +65,9 @@ config:
         Acceptable values are: "info", "debug", "warning", "error" and "critical"
       default: "info"
       type: string
+
+parts:
+  charm:
+    build-packages:
+      - cargo
+      - rustc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ target-version = ["py38"]
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
-select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 extend-ignore = [
     "D203",
     "D204",
@@ -32,10 +34,10 @@ extend-ignore = [
     "D413",
 ]
 ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+select = ["E", "W", "F", "C", "N", "D", "I001"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.codespell]
@@ -43,4 +45,3 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
-

--- a/src/charm.py
+++ b/src/charm.py
@@ -99,7 +99,7 @@ class MsmOperatorCharm(ops.CharmBase):
         self.unit.status = ops.MaintenanceStatus("Assembling pod spec")
 
         # Fetch the new config value
-        log_level = self.model.config["log-level"].lower()
+        log_level = str(self.model.config["log-level"]).lower()
 
         # Do some validation of the configuration options
         if log_level not in VALID_LOG_LEVELS:

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
     # and uncomment the following line
     # codespell {[vars]lib_path}
     codespell {tox_root}
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
- Update ruff configuration on `pyproject.toml`
- Add missing rust packages during charm build time
- convert a config value to string before calling `.lower()`