### PR TITLE
test: extend unit test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 venv/
 build/
 *.charm
@@ -8,3 +9,5 @@ __pycache__/
 .idea
 .vscode/
 **.egg-info
+
+.charm_tracing_buffer.raw


### PR DESCRIPTION
After the release of ops 2.15, the pebble log_targets can be correctly asserted: https://github.com/canonical/operator/releases/tag/2.15.0. This PR is extending unit tests to check `log_targets` content when relating with Loki. In addition, ingress relation is also checked