### PR TITLE
fix: Require Juju 3.6

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,3 +10,5 @@ jobs:
     name: PR
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
     secrets: inherit
+    with:
+      juju-channel: 3.6/stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,3 +9,5 @@ jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     secrets: inherit
+    with:
+      juju-channel: 3.6/stable

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -41,7 +41,7 @@ parts:
       - src/grafana_dashboards/*
 
 assumes:
-  - juju >= 3.3
+  - juju >= 3.6
   - k8s-api
 
 containers:


### PR DESCRIPTION
Juju 3.6 is required for being able to respond to `pebble_check_recovered` events