### PR TITLE
fix: synchronize lib versions with charmstore

### DIFF
--- a/lib/charms/maas_site_manager_k8s/v0/enrol.py
+++ b/lib/charms/maas_site_manager_k8s/v0/enrol.py
@@ -15,11 +15,11 @@ import ops
 LIBID = "c232507f53c34b929e1e7c2bb030d2ce"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
 
 DEFAULT_ENDPOINT_NAME = "maas-site-manager"
 TOKEN_SECRET_KEY = "enrol-token"

--- a/lib/charms/maas_site_manager_k8s/v0/enroll.py
+++ b/lib/charms/maas_site_manager_k8s/v0/enroll.py
@@ -19,7 +19,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 DEFAULT_ENDPOINT_NAME = "maas-site-manager"
 TOKEN_SECRET_KEY = "enroll-token"


### PR DESCRIPTION
Currently, charmstore is reporting the below versions for the two msm libraries:

```bash
~/projects/maas-site-manager-k8s-operator$ charmcraft list-lib
Library name    API    Patch
enrol           1      0
enroll          0      2
```
This PR aligns the git repo with the upstream versions so that the libraries can be properly published